### PR TITLE
Can specify data file with -d, saves run filename to a text file

### DIFF
--- a/code/main.cpp
+++ b/code/main.cpp
@@ -8,9 +8,25 @@ using namespace DNest4;
 
 int main(int argc, char** argv)
 {
-	Data::get_instance().load("../data/sample_data.txt");
-	Sampler<MyModel> sampler = setup<MyModel>(argc, argv);
-	sampler.run();
+    // Process command line options
+    CommandLineOptions clo(argc, argv);
+
+    // Get specified data file. If none, use a default.
+    std::string data_file = clo.get_data_file();
+    if(data_file.length() == 0)
+        data_file = std::string("../data/sample_data.txt");
+
+    // Save the data filename
+    std::fstream fout("run_data.txt", std::ios::out);
+    fout<<data_file;
+    fout.close();
+
+    // Load data
+    Data::get_instance().load(data_file.c_str());
+
+    // Run DNest4.
+    start<MyModel>(clo);
+
 	return 0;
 }
 


### PR DESCRIPTION
It's not super sophisticated, but I've found this pattern useful.

- You can specify a data file on the command line with -d
- If you don't, it just uses the example data
- The data file is saved (as a string) to run_data.txt, so any post-processing script which loads the output knows which data file was used for the run. So you don't have to edit any files to run magnetron2 on different datasets.